### PR TITLE
Dockerfile: switch to python:3.8-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ COPY static/public ./public
 RUN npm install
 RUN PUBLIC_URL=/{{build_path}} npm run build
 
-FROM python:3.8
+FROM python:3.8-alpine
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        libffi-dev \
+        openssl-dev \
+        py3-pip \
+        python3-dev
 RUN pip install pipenv
 WORKDIR /tmp
 COPY Pipfile* ./
@@ -17,6 +23,7 @@ COPY alembic.ini ./
 COPY setup.py ./
 COPY README.md ./
 RUN pip install .
+RUN apk del .build-deps
 CMD alembic upgrade head && python -m feeder
 EXPOSE 1883/tcp
 EXPOSE 5000/tcp


### PR DESCRIPTION
This supports linux/arm/v7 which will allow the image to run on Pi Zero W devices.