### PR TITLE
Match docker-compose.yaml with Wiki Instructions

### DIFF
--- a/sample/docker-compose.yaml
+++ b/sample/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 version: "2.1"
 services:
-  feeder-service:
+  petnet-feeder-service:
     # For Raspberry Pi devices using older processors, we need to specify certain versions
     # in order to make sure docker pulls down the right container. Uncomment the line
     # which fits the device you are running this on.


### PR DESCRIPTION
# Description #
Wiki [Getting Started](https://github.com/petnet-independence-project/petnet-feeder-service/wiki/Getting-Started) instructions say to run `docker-compose start -d petnet-feeder-service`, but this fails as the names do not currently match.

Solves for Issue #40